### PR TITLE
Update contact information in documentation

### DIFF
--- a/constants/LINKS.ts
+++ b/constants/LINKS.ts
@@ -4,9 +4,7 @@ export const LINKS = {
   TERMS: "https://tonapi.io/terms",
   // PRIVACY: "#", // TODO: Add link
   SUPPORT: 'https://t.me/ton_console_bot',
-  CONTACT: 'https://t.me/tonrostislav',
-  CONTACT_EMAIL: 'rostislav.r@tonkeeper.com',
-  ZAKHAR_TG: 'https://t.me/zakhar_petukhov',
+  CONTACT: 'https://t.me/ton_console_bot',
   CONSOLE: 'https://tonconsole.com',
   TONAPI_TECH_CHAT: 'https://t.me/tonapitech',
 } as const;

--- a/pages/payment-processing.mdx
+++ b/pages/payment-processing.mdx
@@ -59,5 +59,4 @@ Share your feedback via [Google Forms](https://forms.gle/NTx1w1ksU5V7fzFB7).
 
 ## Contact Us
 
-- **Email:** <ExternalLink href={'mailto:' + LINKS.CONTACT_EMAIL}> {LINKS.CONTACT_EMAIL} </ExternalLink>  
-- **Telegram:** [Rostislav Rudakov](https://t.me/tonrostislav)  
+- **Telegram:** <ExternalLink href={LINKS.CONTACT}>Support Bot</ExternalLink>

--- a/pages/tonapi/liteservers.mdx
+++ b/pages/tonapi/liteservers.mdx
@@ -1,4 +1,6 @@
 import { Callout } from 'nextra-theme-docs';
+import { ExternalLink } from '@/components';
+import { LINKS } from '@/constants';
 
 # Liteservers
 
@@ -30,7 +32,7 @@ and it is better to specify both for higher fault tolerance (if your software su
 Each plan has its rate limits, which operate on a sliding window algorithm. 
 The window size is 10 seconds. Therefore, with a rate limit of 1 RPS, the maximum number of requests is 10 requests per 10-second period.
 
-The maximum RPS for current plans is 50. Check with the [t.me/tonrostislav](https://t.me/tonrostislav)([rostislav.r@tonkeeper.com](mailto:rostislav.r@tonkeeper.com)) for the custom plan.
+The maximum RPS for current plans is 50. Contact <ExternalLink href={LINKS.SUPPORT}>support</ExternalLink> for the custom plan.
 
 To obtain rate limit data, the service provides an API method:
 

--- a/pages/tonapi/rest-api/rates.mdx
+++ b/pages/tonapi/rest-api/rates.mdx
@@ -40,7 +40,7 @@ If your token has over 100 TON in liquidity but doesn't receive a price from the
 2. Liquidity amount
 3. Number of holders
 
-Send this information to <ExternalLink href={LINKS.ZAKHAR_TG}>@zakhar_petukhov</ExternalLink> for assistance.
+Send this information to <ExternalLink href={LINKS.CONTACT}>our support</ExternalLink> for assistance.
 
 ## Operations
 

--- a/pages/tonconsole/jettons/airdrop.mdx
+++ b/pages/tonconsole/jettons/airdrop.mdx
@@ -1,5 +1,6 @@
 import { Callout } from 'nextra-theme-docs';
-import { ExampleTabs, ExampleTab } from "@/components";
+import { ExampleTabs, ExampleTab, ExternalLink } from "@/components";
+import { LINKS } from '@/constants';
 
 # Jetton Airdrop Technical and Commercial Terms (T&C Terms)
 
@@ -355,4 +356,4 @@ Second, click the `Complete airdrop` button to send special messages that lock t
 After this, you can safely withdraw the remaining Jettons and accumulated TONs from the distribution contracts to the Airdrop admin`s address.
 
 ## If you still have questions
-If you have any questions or need assistance, please write to Mois Ilya at [@moisle](https://t.me/moisle) or [@tonconsole](https://t.me/tonconsole).
+If you have any questions or need assistance, please contact our <ExternalLink href={LINKS.SUPPORT}>support bot</ExternalLink>.

--- a/pages/tonconsole/jettons/mass-sending.mdx
+++ b/pages/tonconsole/jettons/mass-sending.mdx
@@ -1,4 +1,6 @@
 import { Callout } from 'nextra-theme-docs';
+import { ExternalLink } from '@/components';
+import { LINKS } from '@/constants';
 
 # Mass Jetton Sending
 
@@ -8,6 +10,4 @@ A convenient integrated service for mass sending Jettons to multiple recipients.
   This service is currently under development and will be available soon
 </Callout>
 
-If you need this service right now, you can contact us at: <br />
-[rostislav.r@tonkeeper.com](mailto:rostislav.r@tonkeeper.com) <br />
-[t.me/tonrostislav](https://t.me/tonrostislav)
+If you need this service right now, you can contact our <ExternalLink href={LINKS.CONTACT}>support bot</ExternalLink>.


### PR DESCRIPTION
## Why
Some contact details in the documentation are no longer relevant due to team changes. Updated all contact points to use the support bot to ensure users always reach the right place.

## What changed
- Replaced outdated personal contacts with the support bot (`@ton_console_bot`)
- Centralized contact links into `LINKS.SUPPORT` and `LINKS.CONTACT` constants for easy future updates